### PR TITLE
Fix ClamAV socket in Docker setup

### DIFF
--- a/doc/Administration Guide.md
+++ b/doc/Administration Guide.md
@@ -79,3 +79,12 @@ change in generic.json the *storage_db_hostname*
     "storage_db_port": 6101
   }
 ```
+
+#### ClamAV
+
+Change *socket_path* in the ClamAV worker configuration (`/pandora/workers/clamav.yml`) (see [ClamAV Docker Documentation](https://docs.clamav.net/manual/Installing/Docker.html#unix-sockets)).
+
+```yaml
+settings:
+  socket_path: /var/run/clamav/clamd.sock
+```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,7 +18,7 @@ services:
   clamav:
     image: clamav/clamav
     volumes:
-        - /tmp:/var/run/clamav
+        - clamav-socket:/tmp
 
   pandora:
     build: .
@@ -41,10 +41,13 @@ services:
         - ./logs:/pandora/logs
         - ./web_logs:/pandora/website/logs
         - ./tasks:/pandora/tasks
-        - /tmp:/var/run/clamav
+        - clamav-socket:/var/run/clamav
     links:
         - "clamav"
         - "redis"
         - "kvrocks"
     ports:
         - 6100:6100
+
+volumes:
+    clamav-socket:

--- a/pandora/workers/clamav.yml.sample
+++ b/pandora/workers/clamav.yml.sample
@@ -5,3 +5,5 @@ meta:
 
 settings:
   socket_path: /var/run/clamav/clamd.ctl
+  # For docker setup:
+  # socket_path: /var/run/clamav/clamd.sock 


### PR DESCRIPTION
ClamAV uses `/tmp/clamd.sock` as a default location for the socket (see [ClamAV Docker Documentation](https://docs.clamav.net/manual/Installing/Docker.html#unix-sockets)), so `/tmp` needs to be mapped in the container creation and the worker configuration has to be adjusted on setup.

Resolves #126