### PR TITLE
BugFix: Correct issue #399: Waiting on storage to start kvrocks 

### DIFF
--- a/config/docker.json
+++ b/config/docker.json
@@ -1,0 +1,70 @@
+{
+    "loglevel": "INFO",
+    "debug_web": false,
+    "website_listen_ip": "0.0.0.0",
+    "website_listen_port": 6100,
+    "public_url": "http://0.0.0.0:6100",
+    "storage_db_hostname": "kvrocks",
+    "storage_db_port": 6666,
+    "session_expire": 36000,
+    "tasks_max_len": 5000,
+    "max_file_size": 100,
+    "max_days_index": 3,
+    "sample_password": "infected",
+    "default_share_time": 1,
+    "show_project_page": true,
+    "lookyloo_url": "",
+    "users": {},
+    "enable_imap_fetcher": false,
+    "channels": {
+        "enabled": false,
+        "channel_submission": "pandora_submissions"
+    },
+    "misp": {
+        "url": "",
+        "apikey": "",
+        "tls_verify": true
+    },
+    "email": {
+        "smtp_host": "localhost",
+        "smtp_port": "25",
+        "to": ["Investigation Team <investigation_unit@myorg.local>"],
+        "from": "Pandora <pandora@myorg.local>"
+    },
+    "email_smtp_auth": {
+        "auth": false,
+        "smtp_user":"johndoe@myorg.local",
+        "smtp_pass":"password",
+        "smtp_use_starttls": true,
+        "verify_certificate": false
+    },
+    "weasyprint_fetch_ressources": false,
+    "exiftool_path": "",
+    "systemd_service_name": "pandora",
+    "_notes": {
+        "loglevel": "(pandora) Can be one of the value listed here: https://docs.python.org/3/library/logging.html#levels",
+        "debug_web": "If true, launch flask in debug mode. Not suitable for production.",
+        "website_listen_ip": "IP Flask will listen on. Defaults to 0.0.0.0, meaning all interfaces.",
+        "website_listen_port": "Port Flask will listen on.",
+        "public_url": "The public URL used to connect to the interface, it is used for the permaurls sent by mail",
+        "storage_db_hostname": "Hostname or IP of the kvrocks instance. Must be the same as in storage/kvrocks.conf",
+        "storage_db_port": "Port of the kvrocks instance. Must be the same as in storage/kvrocks.conf",
+        "session_expire": "The time (in seconds) before a session expires. Defaults to 10 hours.",
+        "tasks_max_len": "Maximum length of the tasks list.",
+        "max_file_size": "Maximum file size, in Mb. Default: 100Mb.",
+        "max_days_index": "Display tasks up to N days on the index",
+        "sample_password": "Default password used to encrypt the original sample when downloaded from the web interface",
+        "default_share_time": "Default time (in days) the sharing seed will be valid. 0 means forever.",
+        "show_project_page": "If true, display a ribbon with a link to the githug projects page at the top right side of the screen",
+        "lookyloo_url": "The URL of the lookyloo instance you want to connect to. Use the *public* URL, not localhost (the browser blocks that).",
+        "users": "Admin account(s). Format: {username: password}",
+        "enable_imap_fetcher": "If true, the imap fetcher is enabled.",
+        "channels": "If enabled, the submissions are published on the redis pubsub channels",
+        "misp": "The MISP configuration",
+        "email": "Email configuration",
+        "email_smtp_auth": "Email SMTP auth configuration",
+        "weasyprint_fetch_ressources": "If true, weasyprint will fetch resources linked in HTML content",
+        "exiftool_path": "Pandora requires exiftool >=12.15 (check with exiftool -ver), if you have an older version see: https://github.com/sylikc/pyexiftool#pyexiftool-dependencies",
+        "systemd_service_name": "(Optional) Name of the systemd service if your project has one."
+    }
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,7 +33,7 @@ services:
         - ./cache:/pandora/cache
         - ./storage:/pandora/storage
         - ./pandora/workers:/pandora/pandora/workers
-        - ./config:/pandora/config
+        - ./config/docker.json:/pandora/config/generic.json
         - ./yara_rules:/pandora/yara_rules
         - ./yara_repos:/pandora/yara_repos
         - ./logs:/pandora/logs

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,7 +32,8 @@ services:
     volumes:
         - ./cache:/pandora/cache
         - ./storage:/pandora/storage
-        - ./pandora/workers:/pandora/pandora/workers
+        - ./pandora/workers:/pandora/pandora/workers        
+        - ./config:/pandora/config
         - ./config/docker.json:/pandora/config/generic.json
         - ./yara_rules:/pandora/yara_rules
         - ./yara_repos:/pandora/yara_repos

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,9 +6,7 @@ services:
     working_dir: /kvrocks
     volumes:
         - ./storage:/kvrocks/conf
-    ports:
-        - 6101:6101
-
+    command: "--bind 0.0.0.0"
   redis:
     image: redis
     working_dir: /cache

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,7 +32,7 @@ services:
     volumes:
         - ./cache:/pandora/cache
         - ./storage:/pandora/storage
-        - ./pandora/workers:/pandora/pandora/workers        
+        - ./pandora/workers:/pandora/pandora/workers
         - ./config:/pandora/config
         - ./config/docker.json:/pandora/config/generic.json
         - ./yara_rules:/pandora/yara_rules


### PR DESCRIPTION
* The new apache kvrocks docker expose port 6666 and not 6101
* There is an issue on the docker kvrocks binding related to this kvrocks issue [https://github.com/apache/kvrocks/issues/1905](https://github.com/pandora-analysis/pandora/issues/url)