### PR TITLE
Docker: use kvrocks standard port 6666

### DIFF
--- a/config/generic.json.sample
+++ b/config/generic.json.sample
@@ -5,7 +5,7 @@
     "website_listen_port": 6100,
     "public_url": "http://0.0.0.0:6100",
     "storage_db_hostname": "127.0.0.1",
-    "storage_db_port": 6101,
+    "storage_db_port": 6666,
     "session_expire": 36000,
     "tasks_max_len": 5000,
     "max_file_size": 100,

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,8 +6,6 @@ services:
     working_dir: /kvrocks
     volumes:
         - ./storage:/kvrocks/conf
-    ports:
-        - 6101:6666
     command: "--bind 0.0.0.0"
 
   redis:


### PR DESCRIPTION
kvrocks listens on port 6666 in its container.
pandora can reach kvrocks:6666, therefore we don't need to expose kvrocks outside of the pandora network (with compose).