### PR TITLE
Ftoppi patch 5

### DIFF
--- a/config/generic.json.sample
+++ b/config/generic.json.sample
@@ -5,7 +5,7 @@
     "website_listen_port": 6100,
     "public_url": "http://0.0.0.0:6100",
     "storage_db_hostname": "127.0.0.1",
-    "storage_db_port": 6666,
+    "storage_db_port": 6101,
     "session_expire": 36000,
     "tasks_max_len": 5000,
     "max_file_size": 100,

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,9 +6,9 @@ services:
     working_dir: /kvrocks
     volumes:
         - ./storage:/kvrocks/conf
-    command: "--bind 0.0.0.0"
+    command: ["-c", "/kvrocks/conf/kvrocks.conf", "--log-dir", "stdout"]
     healthcheck:
-      test: ["CMD", "redis-cli", "-h", "127.0.0.1", "-p", "6666", "ping"]
+      test: ["CMD", "redis-cli", "-h", "127.0.0.1", "-p", "6101", "ping"]
       interval: 10s
       timeout: 1s
       retries: 3


### PR DESCRIPTION
Hi,

I'm attempting to fix kvrocks in docker.

`kvrocks.conf` is mounted to `/kvrocks/conf/kvrocks.conf` but `apache/kvrocks` looks for the config in `/var/lib/kvrocks` by default (https://github.com/apache/kvrocks/blob/2.8/Dockerfile), thus the config file is never used.

In addition, logging in containers is usually sent to stdout/stderr.

This PR adds arguments to kvrocks to read the proper config file and log to stdout.

Since `kvrocks.conf` is now properly applied, kvrocks listens on port 6101. I have reverted the change to `config/generic.json.sample` .