### PR TITLE
Add a worker to query a MISP instance

### DIFF
--- a/pandora/workers/misp.py
+++ b/pandora/workers/misp.py
@@ -61,8 +61,8 @@ class MISP(BaseWorker):
         report.status = Status.ALERT
         events = []
         for attribute in result['Attribute']:
-          if len(events) < self.max_event_count and attribute['event_id'] not in events:
-            events.append(attribute['event_id'])
+            if len(events) < self.max_event_count and attribute['event_id'] not in events:
+                events.append(attribute['event_id'])
         report.add_details('permaurl', '\n'.join([f'{self.apiurl}/events/view/{i}' for i in events]))
 
         report.add_details('malicious', f'{result["Attribute"][0]["category"]} - {result["Attribute"][0]["comment"]}')

--- a/pandora/workers/misp.py
+++ b/pandora/workers/misp.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import sys
 
-from pymisp import PyMISP, MISPAttribute
+from pymisp import PyMISP
 
 from ..helpers import Status
 from ..task import Task

--- a/pandora/workers/misp.py
+++ b/pandora/workers/misp.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import sys
+
+from pymisp import PyMISP, MISPAttribute
+
+from ..helpers import Status
+from ..task import Task
+from ..report import Report
+
+from .base import BaseWorker, WorkerOption
+
+
+if sys.version_info >= (3, 11):
+    from typing import Unpack
+else:
+    from typing_extensions import Unpack
+
+
+class MISP(BaseWorker):
+
+    apikey: str
+    apiurl: str
+    tls_verify: bool
+    max_event_count: int
+    max_attribute_count: int
+
+    def __init__(self, module: str, worker_id: int, cache: str, timeout: str,
+                 loglevel: int | None=None, **options: Unpack[WorkerOption]) -> None:
+        super().__init__(module, worker_id, cache, timeout, loglevel, **options)
+        if not self.apiurl or self.apiurl == '':
+            self.disabled = True
+            self.logger.warning('Disabled, missing apiurl.')
+            return
+        if not self.apikey or self.apikey == '':
+            self.disabled = True
+            self.logger.warning('Disabled, missing apikey.')
+            return
+        self.logger.info('misp initialized successfully')
+        self.client = PyMISP(self.apiurl, self.apikey, self.tls_verify)
+
+    def analyse(self, task: Task, report: Report, manual_trigger: bool=False) -> None:
+        self.logger.info(f'analysing file {task.file.path}...')
+        try:
+            result = self.client.search(controller='attributes', value=[task.file.md5, task.file.sha1, task.file.sha256], to_ids=1, limit=self.max_attribute_count)
+        except Exception as e:
+            self.logger.error('unable to reach MISP, exception %s', e)
+            report.status = Status.ERROR
+            report.add_details('warning', 'Unable to reach MISP.')
+            return
+
+        if 'Attribute' in result and not result['Attribute']:
+            self.logger.info('no attribute found')
+            report.status = Status.NOTAPPLICABLE
+            return
+
+        # Hash is known so malicious
+        self.logger.info('file %s is malicious', task.file.path)
+        report.status = Status.ALERT
+        events = []
+        for attribute in result['Attribute']:
+          if len(events) < self.max_event_count and attribute['event_id'] not in events:
+            events.append(attribute['event_id'])
+        report.add_details('permaurl', '\n'.join([f'{self.apiurl}/events/view/{i}' for i in events]))
+
+        report.add_details('malicious', f'{result["Attribute"][0]["category"]} - {result["Attribute"][0]["comment"]}')

--- a/pandora/workers/misp.yml.sample
+++ b/pandora/workers/misp.yml.sample
@@ -1,0 +1,10 @@
+meta:
+  name: MISP
+  description: MISP Threat Sharing
+
+settings:
+  apikey: null
+  apiurl: https://misp.example.com
+  tls_verify: true
+  max_event_count: 10
+  max_attribute_count: 10


### PR DESCRIPTION
Hello,

Here is a PR to query a MISP instance using pymisp. It shows the category and comment in the "malicious" box, and the links to events in the "permaurl" box.

```
pandora-pandora-1  | 2024-03-11 14:06:57,188 misp INFO:analysing file /pandora/tasks/2024/03/c4710aed-0cf6-4e3c-87d6-94f4b014d258/33e9edc23449fec91a19e51212967847b97d6d051ecac115a8b0c736022b2322.elf...
pandora-pandora-1  | 2024-03-11 14:06:57,356 misp INFO:file /pandora/tasks/2024/03/c4710aed-0cf6-4e3c-87d6-94f4b014d258/33e9edc23449fec91a19e51212967847b97d6d051ecac115a8b0c736022b2322.elf is malicious
pandora-pandora-1  | 2024-03-11 14:06:57,356 misp INFO:[c4710aed-0cf6-4e3c-87d6-94f4b014d258] Runtime: 0.17s
```

I used the malwarebazaar.py as a start.