### PR TITLE
Improve PDF analysis

### DIFF
--- a/pandora/workers/pdf.py
+++ b/pandora/workers/pdf.py
@@ -2,8 +2,8 @@
 
 from __future__ import annotations
 
-import fitz  # type: ignore[import-untyped]
 import re
+import fitz  # type: ignore[import-untyped]
 
 from ..helpers import Status
 from ..task import Task

--- a/pandora/workers/pdf.py
+++ b/pandora/workers/pdf.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import fitz  # type: ignore[import-untyped]
+import re
 
 from ..helpers import Status
 from ..task import Task
@@ -56,9 +57,10 @@ class Pdf(BaseWorker):
             doc = fitz.open(file_path)
             for xref in range(1, doc.xref_length()):
                 obj_dict = doc.xref_object(xref, compressed=True)
-                # Check for /AA and /OpenAction
-                for keyword in ["/AA", "/OpenAction"]:
-                    if keyword in obj_dict:
+                # Check for /AA, /OpenAction OR /Launch
+                for keyword in ["/AA", "/OpenAction", "/Launch"]:
+                    # Use regex to reduce FPs, especially with /AA
+                    if len(re.findall(keyword + '(?![A-Za-z])', obj_dict)) > 0:
                         suspicious_objects.append(f'{keyword} found in object {xref}: {obj_dict}')
                         # Attempt to extract the object content if possible
                         try:


### PR DESCRIPTION
We have noticed quite some false-positives with the PDF worker because of the `/AA` keyword. Since a simple string search was used, all elements starting with `/AA` are marked as malicious, even though it's not always the case (e.g. some font definitions `/AAAAAA+ArialMT`). This PR changes it to a regex search, making sure the found tag ends right after the keyword. It also adds `/Launch` as a [suspicious keyword](https://ranjitpatil.github.io/malware%20analysis/Malicious-PDF-Document-Analysis/#pdf-fileactions-).