### PR TITLE
Fix Kvrocks DB persistence in Docker deployment

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,8 +5,8 @@ services:
     image: apache/kvrocks
     working_dir: /kvrocks
     volumes:
-        - ./storage:/kvrocks/conf
-    command: ["-c", "/kvrocks/conf/kvrocks.conf", "--log-dir", "stdout"]
+        - ./storage:/var/lib/kvrocks
+    command: ["--log-dir", "stdout"]
     healthcheck:
       test: ["CMD", "redis-cli", "-h", "127.0.0.1", "-p", "6101", "ping"]
       interval: 10s


### PR DESCRIPTION
This should fix the problem reported in #593. With this change the Kvrocks database will be stored in `./storage` just like with a local deployment of Pandora and survive a rebuild/restart of the containters (e.g. `docker compose down/up`).