### PR TITLE
feat(worker): improve odf worker will handling zip archive

### DIFF
--- a/pandora/workers/odf.py
+++ b/pandora/workers/odf.py
@@ -21,12 +21,12 @@ class ODF(BaseWorker):
         self.logger.debug(f'analysing file {task.file.path}...')
 
         try:
-            lodoc = zipfile.ZipFile(task.file.path, 'r')
-            for f in lodoc.infolist():
-                fname = f.filename.lower()
-                if fname.startswith('script') or fname.startswith('basic') or \
-                        fname.startswith('object') or fname.endswith('.bin'):
-                    report.status = Status.ALERT
-                    report.add_details('warning', "The file contains an indicator that could be related to a macro")
+            with zipfile.ZipFile(task.file.path, 'r') as lodoc:
+                for f in lodoc.infolist():
+                    fname = f.filename.lower()
+                    if fname.startswith('script') or fname.startswith('basic') or \
+                            fname.startswith('object') or fname.endswith('.bin'):
+                        report.status = Status.ALERT
+                        report.add_details('warning', "The file contains an indicator that could be related to a macro")
         except Exception as e:
             raise e


### PR DESCRIPTION
Hello, 

Following up the comment in the Issue #926, I identify a stability improvement that could impact the ODF worker. 

This PR introduces the following minor change: 

1. Implemented a `with ... as ...:` context manager to ensure the file descriptor is safely closed in case of errors. 

The core detection logic remains unchanged. 

Thanks! 