### PR TITLE
new: Expose file metadata via /task_metadata API endpoint

### DIFF
--- a/website/web/generic_api.py
+++ b/website/web/generic_api.py
@@ -227,6 +227,31 @@ class ApiTaskStatus(Resource):  # type: ignore[misc]
         return to_return
 
 
+task_metadata_parser = api.parser()
+task_metadata_parser.add_argument('task_id', required=True,
+                                  location='args',
+                                  help="The id of the task you'd like to get the file metadata from")
+task_metadata_parser.add_argument('seed', required=False,
+                                  location='args',
+                                  help="A seed allowing you so see the task (if not admin)")
+
+
+@api.route('/task_metadata', methods=['GET'], strict_slashes=False)
+@api.expect(task_metadata_parser)
+class ApiTaskMetadata(Resource):  # type: ignore[misc]
+
+    @json_answer
+    def get(self) -> dict[str, Any]:
+        args = task_metadata_parser.parse_args(request)
+        task_id = args['task_id']
+        seed = args['seed'] if args.get('seed') else None
+        task = pandora.get_task(task_id=task_id)
+        update_user_role(pandora, task, seed)
+        if not flask_login.current_user.role.can(Action.read_analysis):
+            raise Forbidden('Not allowed to read the report')
+        return {'success': True, 'taskId': task.uuid, 'metadata': task.file.metadata}
+
+
 worker_parser = api.parser()
 worker_parser.add_argument('task_id', required=True,
                            location='args',


### PR DESCRIPTION
# Expose file metadata via `/task_metadata` API endpoint

Fix #988 — as discussed there, this adds a `/task_metadata` GET endpoint so API consumers (e.g. via pypandora) can retrieve the exiftool-derived document metadata (`task.file.metadata`) that the web UI already renders in the **Metadata** tab.

## Changes

- New `task_metadata_parser` (`task_id` required, `seed` optional) and `ApiTaskMetadata` resource in `website/web/generic_api.py`, mirroring `/task_observables`:
  - same `update_user_role(pandora, task, seed)` flow,
  - same `Action.read_analysis` permission gate (403 via `json_answer` otherwise),
  - returns `{"success": true, "taskId": <uuid>, "metadata": {...}}`.

No existing code paths are modified — the change is purely additive.

## Companion PR

The matching client method: pandora-analysis/pypandora#78

## Side note (pre-existing, not touched here)

While mirroring the pattern I noticed `ApiTaskObservables.get()` parses args with `status_parser` instead of its own `task_observables_parser` — harmless today since both define `task_id`/`seed`, but worth a cleanup at some point. Happy to include it here if you prefer.